### PR TITLE
Magic functions for `s4n tool create` parser

### DIFF
--- a/src/commands/tool.rs
+++ b/src/commands/tool.rs
@@ -1,7 +1,7 @@
 use crate::{
     cwl::{
         format::format_cwl,
-        parser,
+        parser::{self, post_process_cwl},
         requirements::{DockerRequirement, Requirement},
     },
     io::{create_and_write_file, get_qualified_filename},
@@ -152,6 +152,8 @@ pub fn create_tool(args: &CreateToolArgs) -> Result<(), Box<dyn Error>> {
             cwl = cwl.with_requirements(vec![requirement])
         }
     }
+
+    post_process_cwl(&mut cwl);
 
     //generate yaml
     if !args.is_raw {

--- a/src/cwl/clt.rs
+++ b/src/cwl/clt.rs
@@ -100,6 +100,10 @@ impl CommandLineTool {
         self.stderr = stderr;
         self
     }
+    pub fn with_arguments(mut self, args: Option<Vec<Argument>>) -> Self {
+        self.arguments = args;
+        self
+    }
 }
 
 impl Display for CommandLineTool {

--- a/src/cwl/clt.rs
+++ b/src/cwl/clt.rs
@@ -96,6 +96,10 @@ impl CommandLineTool {
         self.stdout = stdout;
         self
     }
+    pub fn with_stderr(mut self, stderr: Option<String>) -> Self {
+        self.stderr = stderr;
+        self
+    }
 }
 
 impl Display for CommandLineTool {

--- a/src/cwl/clt.rs
+++ b/src/cwl/clt.rs
@@ -92,6 +92,10 @@ impl CommandLineTool {
         self.requirements = Some(requirements);
         self
     }
+    pub fn with_stdout(mut self, stdout: Option<String>) -> Self {
+        self.stdout = stdout;
+        self
+    }
 }
 
 impl Display for CommandLineTool {

--- a/src/cwl/parser.rs
+++ b/src/cwl/parser.rs
@@ -127,7 +127,7 @@ fn get_option(current: &str, next: &str) -> CommandInputParameter {
 }
 
 fn handle_redirection(remaining_args: &[&str]) -> Option<String> {
-    if remaining_args.len() == 0 {
+    if remaining_args.is_empty() {
         return None;
     }
     //hopefully? most cases are only `some_command > some_file.out`

--- a/src/cwl/parser.rs
+++ b/src/cwl/parser.rs
@@ -11,7 +11,7 @@ use slugify::slugify;
 use std::path::Path;
 
 //TODO complete list
-static SCRIPT_EXECUTORS: &[&str] = &["python", "Rscript"];
+static SCRIPT_EXECUTORS: &[&str] = &["python", "Rscript", "cwltool"];
 
 pub fn parse_command_line(command: Vec<&str>) -> CommandLineTool {
     let base_command = get_base_command(&command);

--- a/src/cwl/parser.rs
+++ b/src/cwl/parser.rs
@@ -29,7 +29,7 @@ pub fn parse_command_line(command: Vec<&str>) -> CommandLineTool {
 
         let stdout = handle_redirection(&remainder[stdout_pos + 1..]);
         let stderr = handle_redirection(&remainder[stderr_pos + 1..]);
-
+        println!("{remainder:?}");
         let inputs = get_inputs(&remainder[..first_redir_pos]);
 
         tool = tool.with_inputs(inputs).with_stdout(stdout).with_stderr(stderr);

--- a/src/cwl/parser.rs
+++ b/src/cwl/parser.rs
@@ -20,12 +20,20 @@ pub fn parse_command_line(command: Vec<&str>) -> CommandLineTool {
         Command::Multiple(ref vec) => &command[vec.len()..],
     };
 
-    let redirect_position = remainder.iter().position(|i| *i == ">").unwrap_or(remainder.len());
-    let stdout = handle_redirection(&remainder[redirect_position + 1..]);
+    let stdout_pos = remainder.iter().position(|i| *i == ">").unwrap_or(remainder.len() - 1);
+    let stderr_pos = remainder.iter().position(|i| *i == "2>").unwrap_or(remainder.len() - 1);
+    let first_redir_pos = usize::min(stdout_pos, stderr_pos);
 
-    let inputs = get_inputs(&remainder[..redirect_position]);
+    let stdout = handle_redirection(&remainder[stdout_pos + 1..]);
+    let stderr = handle_redirection(&remainder[stderr_pos + 1..]);
 
-    let tool = CommandLineTool::default().with_base_command(base_command.clone()).with_inputs(inputs).with_stdout(stdout);
+    let inputs = get_inputs(&remainder[..first_redir_pos]);
+
+    let tool = CommandLineTool::default()
+        .with_base_command(base_command.clone())
+        .with_inputs(inputs)
+        .with_stdout(stdout)
+        .with_stderr(stderr);
 
     match base_command {
         Command::Single(_) => tool,

--- a/src/cwl/parser.rs
+++ b/src/cwl/parser.rs
@@ -215,6 +215,26 @@ pub fn post_process_cwl(tool: &mut CommandLineTool) {
                     processed_once = true;
                 }
             }
+            if let Some(arguments) = &mut tool.arguments {
+                for argument in arguments.iter_mut() {
+                    match argument {
+                        Argument::String(s) => {
+                            if *s == default.as_value_string() {
+                                *s = process_input(input);
+                                processed_once = true;
+                            }
+                        }
+                        Argument::Binding(binding) => {
+                            if let Some(from) = &mut binding.value_from {
+                                if *from == default.as_value_string() {
+                                    *from = process_input(input);
+                                    processed_once = true;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/src/cwl/parser.rs
+++ b/src/cwl/parser.rs
@@ -11,7 +11,7 @@ use slugify::slugify;
 use std::path::Path;
 
 //TODO complete list
-static SCRIPT_EXECUTORS: &[&str] = &["python", "Rscript", "cwltool"];
+static SCRIPT_EXECUTORS: &[&str] = &["python", "Rscript"];
 
 pub fn parse_command_line(command: Vec<&str>) -> CommandLineTool {
     let base_command = get_base_command(&command);
@@ -23,13 +23,13 @@ pub fn parse_command_line(command: Vec<&str>) -> CommandLineTool {
     let mut tool = CommandLineTool::default().with_base_command(base_command.clone());
 
     if !remainder.is_empty() {
-        let stdout_pos = remainder.iter().position(|i| *i == ">").unwrap_or(remainder.len() - 1);
-        let stderr_pos = remainder.iter().position(|i| *i == "2>").unwrap_or(remainder.len() - 1);
+        let stdout_pos = remainder.iter().position(|i| *i == ">").unwrap_or(remainder.len());
+        let stderr_pos = remainder.iter().position(|i| *i == "2>").unwrap_or(remainder.len());
         let first_redir_pos = usize::min(stdout_pos, stderr_pos);
 
-        let stdout = handle_redirection(&remainder[stdout_pos + 1..]);
-        let stderr = handle_redirection(&remainder[stderr_pos + 1..]);
-        println!("{remainder:?}");
+        let stdout = handle_redirection(&remainder[stdout_pos..]);
+        let stderr = handle_redirection(&remainder[stderr_pos..]);
+        println!("{:?}",&remainder[..first_redir_pos]);
         let inputs = get_inputs(&remainder[..first_redir_pos]);
 
         tool = tool.with_inputs(inputs).with_stdout(stdout).with_stderr(stderr);
@@ -139,7 +139,8 @@ fn handle_redirection(remaining_args: &[&str]) -> Option<String> {
         return None;
     }
     //hopefully? most cases are only `some_command > some_file.out`
-    let out_file = remaining_args[0];
+    //remdirect comes at pos 0, discard that
+    let out_file = remaining_args[1];
     Some(out_file.to_string())
 }
 

--- a/src/cwl/parser.rs
+++ b/src/cwl/parser.rs
@@ -20,20 +20,20 @@ pub fn parse_command_line(command: Vec<&str>) -> CommandLineTool {
         Command::Multiple(ref vec) => &command[vec.len()..],
     };
 
-    let stdout_pos = remainder.iter().position(|i| *i == ">").unwrap_or(remainder.len() - 1);
-    let stderr_pos = remainder.iter().position(|i| *i == "2>").unwrap_or(remainder.len() - 1);
-    let first_redir_pos = usize::min(stdout_pos, stderr_pos);
+    let mut tool = CommandLineTool::default().with_base_command(base_command.clone());
 
-    let stdout = handle_redirection(&remainder[stdout_pos + 1..]);
-    let stderr = handle_redirection(&remainder[stderr_pos + 1..]);
+    if !remainder.is_empty() {
+        let stdout_pos = remainder.iter().position(|i| *i == ">").unwrap_or(remainder.len() - 1);
+        let stderr_pos = remainder.iter().position(|i| *i == "2>").unwrap_or(remainder.len() - 1);
+        let first_redir_pos = usize::min(stdout_pos, stderr_pos);
 
-    let inputs = get_inputs(&remainder[..first_redir_pos]);
+        let stdout = handle_redirection(&remainder[stdout_pos + 1..]);
+        let stderr = handle_redirection(&remainder[stderr_pos + 1..]);
 
-    let tool = CommandLineTool::default()
-        .with_base_command(base_command.clone())
-        .with_inputs(inputs)
-        .with_stdout(stdout)
-        .with_stderr(stderr);
+        let inputs = get_inputs(&remainder[..first_redir_pos]);
+
+        tool = tool.with_inputs(inputs).with_stdout(stdout).with_stderr(stderr);
+    }
 
     match base_command {
         Command::Single(_) => tool,

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -13,7 +13,7 @@ pub fn get_modified_files(repo: &Repository) -> Vec<String> {
             for entry in statuses.iter() {
                 let status = entry.status();
                 let path = entry.path().unwrap_or("unknown").to_owned();
-                if status == Status::WT_MODIFIED || status == Status::WT_NEW {
+                if status.contains(Status::WT_MODIFIED) || status.contains(Status::WT_NEW) {
                     files.push(path);
                 }
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@ use syntect::{
 };
 use sysinfo::System;
 
-pub fn error(message: &str) -> String{
+pub fn error(message: &str) -> String {
     format!("❌ {}: {}", "Error".red().bold(), message.red())
 }
 
@@ -58,4 +58,15 @@ pub fn format_command(command: &Command) -> String {
         .collect();
 
     format!("{} {}", program, args.join(" "))
+}
+
+pub fn split_vec_at<T: PartialEq + Clone, C: AsRef<[T]>>(vec: C, split_at: T) -> (Vec<T>, Vec<T>) {
+    let slice = vec.as_ref();
+    if let Some(index) = slice.iter().position(|x| *x == split_at) {
+        let lhs = slice[..index].to_vec();
+        let rhs = slice[index + 1..].to_vec();
+        (lhs, rhs)
+    } else {
+        (slice.to_vec(), vec![])
+    }
 }

--- a/tests/command_parser_test.rs
+++ b/tests/command_parser_test.rs
@@ -191,3 +191,13 @@ pub fn test_parse_pipe_op() {
 
     assert!(tool.stdout.is_none()); //as it is in args!
 }
+
+#[test]
+pub fn test_parse_magic() {
+    let command = "mkdir test_directory";
+    let split_params = shlex::split(command).unwrap();
+    let tool = parse_command_line(split_params.iter().map(AsRef::as_ref).collect());
+
+    let first_binding = &tool.outputs[0].output_binding;
+    
+}

--- a/tests/command_parser_test.rs
+++ b/tests/command_parser_test.rs
@@ -148,3 +148,12 @@ pub fn test_parse_redirect() {
     
     assert!(tool.stdout == Some("output.txt".to_string()))
 }
+
+#[test]
+pub fn test_parse_redirect_stderr() {
+    let command = "cat tests/test_data/inputtxt 2\\> err.txt";
+    let split_params = shlex::split(command).unwrap();
+    let tool = parse_command_line(split_params.iter().map(AsRef::as_ref).collect());
+
+    assert!(tool.stderr == Some("err.txt".to_string()))
+}

--- a/tests/command_parser_test.rs
+++ b/tests/command_parser_test.rs
@@ -1,7 +1,7 @@
 mod common;
 use common::with_temp_repository;
 use s4n::cwl::{
-    clt::{Command, CommandLineTool},
+    clt::{Argument, Command, CommandLineTool},
     inputs::{CommandInputParameter, CommandLineBinding},
     outputs::{CommandOutputBinding, CommandOutputParameter},
     parser::{get_outputs, parse_command_line},
@@ -18,13 +18,17 @@ pub fn test_cases() -> Vec<(String, CommandLineTool)> {
             "python script.py".to_string(),
             CommandLineTool::default()
                 .with_base_command(Command::Multiple(vec!["python".to_string(), "script.py".to_string()]))
-                .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file("script.py"))]),
+                .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file(
+                    "script.py",
+                ))]),
         ),
         (
             "Rscript script.R".to_string(),
             CommandLineTool::default()
                 .with_base_command(Command::Multiple(vec!["Rscript".to_string(), "script.R".to_string()]))
-                .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file("script.R"))]),
+                .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file(
+                    "script.R",
+                ))]),
         ),
         (
             "python script.py --option1 value1".to_string(),
@@ -35,7 +39,9 @@ pub fn test_cases() -> Vec<(String, CommandLineTool)> {
                     .with_type(CWLType::String)
                     .with_binding(CommandLineBinding::default().with_prefix(&"--option1".to_string()))
                     .with_default_value(DefaultValue::Any(Value::String("value1".to_string())))])
-                .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file("script.py"))]),
+                .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file(
+                    "script.py",
+                ))]),
         ),
         (
             "python script.py --option1 \"value with spaces\"".to_string(),
@@ -46,7 +52,9 @@ pub fn test_cases() -> Vec<(String, CommandLineTool)> {
                     .with_type(CWLType::String)
                     .with_binding(CommandLineBinding::default().with_prefix(&"--option1".to_string()))
                     .with_default_value(DefaultValue::Any(Value::String("value with spaces".to_string())))])
-                .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file("script.py"))]),
+                .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file(
+                    "script.py",
+                ))]),
         ),
         (
             "python script.py positional1 --option1 value1".to_string(),
@@ -64,7 +72,9 @@ pub fn test_cases() -> Vec<(String, CommandLineTool)> {
                         .with_binding(CommandLineBinding::default().with_prefix(&"--option1".to_string()))
                         .with_default_value(DefaultValue::Any(Value::String("value1".to_string()))),
                 ])
-                .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file("script.py"))]),
+                .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file(
+                    "script.py",
+                ))]),
         ),
     ]
 }
@@ -93,7 +103,9 @@ pub fn test_parse_command_line_testdata() {
                 .with_type(CWLType::File)
                 .with_binding(CommandLineBinding::default().with_prefix(&"--test".to_string()))
                 .with_default_value(DefaultValue::File(File::from_location(&"data/input.txt".to_string())))])
-            .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file("scripts/echo.py"))]);
+            .with_requirements(vec![Requirement::InitialWorkDirRequirement(InitialWorkDirRequirement::from_file(
+                "scripts/echo.py",
+            ))]);
         assert_eq!(cwl, expected);
     });
 }
@@ -127,7 +139,9 @@ pub fn test_get_outputs() {
         CommandOutputParameter::default()
             .with_type(CWLType::File)
             .with_id("my-file")
-            .with_binding(CommandOutputBinding { glob: "my-file.txt".to_string() }),
+            .with_binding(CommandOutputBinding {
+                glob: "my-file.txt".to_string(),
+            }),
         CommandOutputParameter::default()
             .with_type(CWLType::File)
             .with_id("archive")
@@ -145,8 +159,8 @@ pub fn test_parse_redirect() {
     let command = "cat tests/test_data/input.txt \\> output.txt";
     let split_params = shlex::split(command).unwrap();
     let tool = parse_command_line(split_params.iter().map(AsRef::as_ref).collect());
-    
-    assert!(tool.stdout == Some("output.txt".to_string()))
+
+    assert!(tool.stdout == Some("output.txt".to_string()));
 }
 
 #[test]
@@ -155,5 +169,25 @@ pub fn test_parse_redirect_stderr() {
     let split_params = shlex::split(command).unwrap();
     let tool = parse_command_line(split_params.iter().map(AsRef::as_ref).collect());
 
-    assert!(tool.stderr == Some("err.txt".to_string()))
+    assert!(tool.stderr == Some("err.txt".to_string()));
+}
+
+#[test]
+pub fn test_parse_pipe_op() {
+    let command = "df \\| grep --line-buffered tmpfs \\> df.log";
+    let split_params = shlex::split(command).unwrap();
+    let tool = parse_command_line(split_params.iter().map(AsRef::as_ref).collect());
+
+    assert!(tool.arguments.is_some());
+    assert!(tool.has_shell_command_requirement());
+
+    if let Some(args) = tool.arguments {
+        if let Argument::Binding(pipe) = &args[0] {
+            assert!(pipe.value_from == Some("|".to_string()));
+        } else {
+            panic!();
+        }
+    }
+
+    assert!(tool.stdout.is_none()); //as it is in args!
 }

--- a/tests/command_parser_test.rs
+++ b/tests/command_parser_test.rs
@@ -139,3 +139,12 @@ pub fn test_get_outputs() {
     let outputs = get_outputs(files);
     assert_eq!(outputs, expected);
 }
+
+#[test]
+pub fn test_parse_redirect() {
+    let command = "cat tests/test_data/input.txt \\> output.txt";
+    let split_params = shlex::split(&command).unwrap();
+    let tool = parse_command_line(split_params.iter().map(AsRef::as_ref).collect());
+    
+    assert!(tool.stdout == Some("output.txt".to_string()))
+}

--- a/tests/command_parser_test.rs
+++ b/tests/command_parser_test.rs
@@ -143,7 +143,7 @@ pub fn test_get_outputs() {
 #[test]
 pub fn test_parse_redirect() {
     let command = "cat tests/test_data/input.txt \\> output.txt";
-    let split_params = shlex::split(&command).unwrap();
+    let split_params = shlex::split(command).unwrap();
     let tool = parse_command_line(split_params.iter().map(AsRef::as_ref).collect());
     
     assert!(tool.stdout == Some("output.txt".to_string()))

--- a/tests/command_parser_test.rs
+++ b/tests/command_parser_test.rs
@@ -191,13 +191,3 @@ pub fn test_parse_pipe_op() {
 
     assert!(tool.stdout.is_none()); //as it is in args!
 }
-
-#[test]
-pub fn test_parse_magic() {
-    let command = "mkdir test_directory";
-    let split_params = shlex::split(command).unwrap();
-    let tool = parse_command_line(split_params.iter().map(AsRef::as_ref).collect());
-
-    let first_binding = &tool.outputs[0].output_binding;
-    
-}

--- a/tests/tool_integration_test.rs
+++ b/tests/tool_integration_test.rs
@@ -285,7 +285,7 @@ pub fn test_tool_magic_outputs() {
 
         let tool = load_tool("workflows/touch/touch.cwl").unwrap();
 
-        assert!(tool.outputs[0].output_binding.as_ref().unwrap().glob == "$(inputs.output_txt)".to_string());
+        assert!(tool.outputs[0].output_binding.as_ref().unwrap().glob == *"$(inputs.output_txt)");
     });
 }
 
@@ -308,6 +308,6 @@ pub fn test_tool_magic_stdout() {
         assert!(create_tool(&args).is_ok());
 
         let tool = load_tool("workflows/wc/wc.cwl").unwrap();
-        assert!(tool.stdout.unwrap() == "$(inputs.data_input_txt.path)".to_string());
+        assert!(tool.stdout.unwrap() == *"$(inputs.data_input_txt.path)");
     });
 }

--- a/tests/tool_integration_test.rs
+++ b/tests/tool_integration_test.rs
@@ -2,9 +2,10 @@ mod common;
 use common::{os_path, with_temp_repository};
 use git2::Repository;
 use s4n::{
-    commands::tool::{handle_tool_commands, CreateToolArgs, ToolCommands},
+    commands::tool::{create_tool, handle_tool_commands, CreateToolArgs, ToolCommands},
     cwl::{
         clt::CommandLineTool,
+        loader::load_tool,
         requirements::{DockerRequirement, Requirement},
         types::Entry,
     },
@@ -25,13 +26,21 @@ pub fn tool_create_test() {
             no_commit: false,
             no_run: false,
             is_clean: false,
-            command: vec!["python".to_string(), "scripts/echo.py".to_string(), "--test".to_string(), "data/input.txt".to_string()],
+            command: vec![
+                "python".to_string(),
+                "scripts/echo.py".to_string(),
+                "--test".to_string(),
+                "data/input.txt".to_string(),
+            ],
         };
         let cmd = ToolCommands::Create(tool_create_args);
         assert!(handle_tool_commands(&cmd).is_ok());
 
         //check for files being present
-        let output_paths = vec![dir.path().join(Path::new("results.txt")), dir.path().join(Path::new("workflows/echo/echo.cwl"))];
+        let output_paths = vec![
+            dir.path().join(Path::new("results.txt")),
+            dir.path().join(Path::new("workflows/echo/echo.cwl")),
+        ];
         for output_path in output_paths {
             assert!(output_path.exists());
         }
@@ -54,7 +63,12 @@ pub fn tool_create_test_is_raw() {
             no_commit: false,
             no_run: false,
             is_clean: false,
-            command: vec!["python".to_string(), "scripts/echo.py".to_string(), "--test".to_string(), "data/input.txt".to_string()],
+            command: vec![
+                "python".to_string(),
+                "scripts/echo.py".to_string(),
+                "--test".to_string(),
+                "data/input.txt".to_string(),
+            ],
         };
         let cmd = ToolCommands::Create(tool_create_args);
         assert!(handle_tool_commands(&cmd).is_ok());
@@ -79,13 +93,21 @@ pub fn tool_create_test_no_commit() {
             no_commit: true, //look!
             no_run: false,
             is_clean: false,
-            command: vec!["python".to_string(), "scripts/echo.py".to_string(), "--test".to_string(), "data/input.txt".to_string()],
+            command: vec![
+                "python".to_string(),
+                "scripts/echo.py".to_string(),
+                "--test".to_string(),
+                "data/input.txt".to_string(),
+            ],
         };
         let cmd = ToolCommands::Create(tool_create_args);
         assert!(handle_tool_commands(&cmd).is_ok());
 
         //check for files being present
-        let output_paths = vec![dir.path().join(Path::new("results.txt")), dir.path().join(Path::new("workflows/echo/echo.cwl"))];
+        let output_paths = vec![
+            dir.path().join(Path::new("results.txt")),
+            dir.path().join(Path::new("workflows/echo/echo.cwl")),
+        ];
         for output_path in output_paths {
             assert!(output_path.exists());
         }
@@ -107,7 +129,12 @@ pub fn tool_create_test_no_run() {
             no_commit: false,
             no_run: true, //look!
             is_clean: false,
-            command: vec!["python".to_string(), "scripts/echo.py".to_string(), "--test".to_string(), "data/input.txt".to_string()],
+            command: vec![
+                "python".to_string(),
+                "scripts/echo.py".to_string(),
+                "--test".to_string(),
+                "data/input.txt".to_string(),
+            ],
         };
         let cmd = ToolCommands::Create(tool_create_args);
         assert!(handle_tool_commands(&cmd).is_ok());
@@ -131,7 +158,12 @@ pub fn tool_create_test_is_clean() {
             no_commit: false,
             no_run: false,
             is_clean: true, //look!
-            command: vec!["python".to_string(), "scripts/echo.py".to_string(), "--test".to_string(), "data/input.txt".to_string()],
+            command: vec![
+                "python".to_string(),
+                "scripts/echo.py".to_string(),
+                "--test".to_string(),
+                "data/input.txt".to_string(),
+            ],
         };
         let cmd = ToolCommands::Create(tool_create_args);
         assert!(handle_tool_commands(&cmd).is_ok());
@@ -156,7 +188,12 @@ pub fn tool_create_test_container_image() {
             no_commit: false,
             no_run: false,
             is_clean: false,
-            command: vec!["python".to_string(), "scripts/echo.py".to_string(), "--test".to_string(), "data/input.txt".to_string()],
+            command: vec![
+                "python".to_string(),
+                "scripts/echo.py".to_string(),
+                "--test".to_string(),
+                "data/input.txt".to_string(),
+            ],
         };
         let cmd = ToolCommands::Create(tool_create_args);
         assert!(handle_tool_commands(&cmd).is_ok());
@@ -193,7 +230,12 @@ pub fn tool_create_test_dockerfile() {
             no_commit: false,
             no_run: false,
             is_clean: false,
-            command: vec!["python".to_string(), "scripts/echo.py".to_string(), "--test".to_string(), "data/input.txt".to_string()],
+            command: vec![
+                "python".to_string(),
+                "scripts/echo.py".to_string(),
+                "--test".to_string(),
+                "data/input.txt".to_string(),
+            ],
         };
         let cmd = ToolCommands::Create(tool_create_args);
         assert!(handle_tool_commands(&cmd).is_ok());
@@ -206,7 +248,11 @@ pub fn tool_create_test_dockerfile() {
         let requirements = cwl.requirements.expect("No requirements found!");
         assert_eq!(requirements.len(), 2);
 
-        if let Requirement::DockerRequirement(DockerRequirement::DockerFile { docker_file, docker_image_id }) = &requirements[1] {
+        if let Requirement::DockerRequirement(DockerRequirement::DockerFile {
+            docker_file,
+            docker_image_id,
+        }) = &requirements[1]
+        {
             assert_eq!(*docker_file, Entry::from_file(&os_path("../../Dockerfile"))); //as file is in root and cwl in workflows/echo
             assert_eq!(*docker_image_id, "sciwin-client".to_string());
         } else {
@@ -216,5 +262,29 @@ pub fn tool_create_test_dockerfile() {
         //no uncommitted left?
         let repo = Repository::open(dir.path()).unwrap();
         assert!(get_modified_files(&repo).is_empty());
+    });
+}
+
+#[test]
+#[serial]
+pub fn test_tool_magic_outputs() {
+    with_temp_repository(|_| {
+        let str = "touch output.txt";
+        let args = CreateToolArgs {
+            name: None,
+            container_image: None,
+            container_tag: None,
+            is_raw: false,
+            no_commit: true,
+            no_run: false,
+            is_clean: true,
+            command: shlex::split(str).unwrap(),
+        };
+
+        assert!(create_tool(&args).is_ok());
+
+        let tool = load_tool("workflows/touch/touch.cwl").unwrap();
+
+        assert!(tool.outputs[0].output_binding.as_ref().unwrap().glob == "$(inputs.output_txt)".to_string());
     });
 }

--- a/tests/tool_integration_test.rs
+++ b/tests/tool_integration_test.rs
@@ -288,3 +288,26 @@ pub fn test_tool_magic_outputs() {
         assert!(tool.outputs[0].output_binding.as_ref().unwrap().glob == "$(inputs.output_txt)".to_string());
     });
 }
+
+#[test]
+#[serial]
+pub fn test_tool_magic_stdout() {
+    with_temp_repository(|_| {
+        let str = "wc data/input.txt \\> data/input.txt";
+        let args = CreateToolArgs {
+            name: None,
+            container_image: None,
+            container_tag: None,
+            is_raw: false,
+            no_commit: true,
+            no_run: false,
+            is_clean: true,
+            command: shlex::split(str).unwrap(),
+        };
+
+        assert!(create_tool(&args).is_ok());
+
+        let tool = load_tool("workflows/wc/wc.cwl").unwrap();
+        assert!(tool.stdout.unwrap() == "$(inputs.data_input_txt.path)".to_string());
+    });
+}


### PR DESCRIPTION
List of features:
- Handle redirection operator: `s4n tool create cat tests/test_data/input.txt \> output.txt` creates proper tool (notice operator needs to be escaped by backspace!)
- Redirection of `stderr` also works! `s4n tool create python stderr.py 2\> err.txt`
- Handling of Pipe Operator: e.g. `s4n tool create df \| grep --line-buffered tmpfs \> df.log`
- Replace hardcoded paths that reference input values with `$(inputs.[inputId])` at some points