### PR TITLE
Potential fix for code scanning alert no. 281: Uncontrolled data used in path expression

### DIFF
--- a/packages/core/src/project.rs
+++ b/packages/core/src/project.rs
@@ -5,7 +5,7 @@ use repository::{commit, get_modified_files, initial_commit, stage_all};
 use std::env;
 use std::{
     fs,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 use std::{fs::File, io::Write};
 
@@ -98,27 +98,40 @@ fn create_minimal_folder_structure(base_dir: &Path) -> anyhow::Result<()> {
 }
 
 fn verify_base_dir(folder: &Path) -> Result<PathBuf> {
-    let path = if folder.is_absolute() {
-        folder.to_path_buf()
-    } else {
-        env::current_dir()?.join(folder)
-    };
+    let cwd = env::current_dir()?.canonicalize()?;
 
-    if path.exists() {
+    if folder.is_absolute() {
+        anyhow::bail!("Provided path must be relative to the current working directory: {folder:?}");
+    }
+
+    if folder
+        .components()
+        .any(|component| matches!(component, Component::ParentDir))
+    {
+        anyhow::bail!("Provided path must not contain parent directory traversal ('..'): {folder:?}");
+    }
+
+    let path = cwd.join(folder);
+
+    let resolved = if path.exists() {
         if path.is_file() {
             anyhow::bail!("Provided path is a file, expected a directory: {path:?}");
         }
 
-        return path
-            .canonicalize()
-            .with_context(|| format!("Could not canonicalize {path:?}"));
+        path.canonicalize()
+            .with_context(|| format!("Could not canonicalize {path:?}"))?
+    } else {
+        let parent = path.parent().context("Path has to parent")?;
+        let parent = parent.canonicalize()?;
+        let foldername = path.file_name().context("Path has to filename")?;
+        parent.join(foldername)
+    };
+
+    if !resolved.starts_with(&cwd) {
+        anyhow::bail!("Resolved path escapes current working directory: {resolved:?}");
     }
 
-    let parent = path.parent().context("Path has to parent")?;
-    let parent = parent.canonicalize()?;
-    let foldername = path.file_name().context("Path has to filename")?;
-
-    Ok(parent.join(foldername))
+    Ok(resolved)
 }
 
 fn create_arc_folder_structure(base_dir: &Path) -> anyhow::Result<()> {


### PR DESCRIPTION
Potential fix for [https://github.com/fairagro/sciwin/security/code-scanning/281](https://github.com/fairagro/sciwin/security/code-scanning/281)

General fix: validate and constrain the resolved path before using it in filesystem operations. The safest pattern is to resolve against an allowlisted base directory and reject paths that escape it.

Best fix here without changing broad behavior too much: harden `verify_base_dir` so it rejects dangerous relative inputs (`..`, separators in components are inherently handled by component parsing) and ensures the final resolved path is under the current working directory. This matches the current implicit behavior of joining relative paths to `current_dir`, while preventing traversal/escape and suspicious component use. Then downstream functions (`create_arc_folder_structure`) can continue using the returned validated path unchanged.

Edit region: `packages/core/src/project.rs`, function `verify_base_dir` (lines ~100–122 in snippet).  
Needed changes:
- Use `std::path::Component` to inspect path components.
- Reject absolute input (to enforce confinement) and any `ParentDir` traversal.
- Build candidate path from `current_dir().join(folder)`.
- Canonicalize existing candidates; for non-existing targets canonicalize parent then append leaf.
- Ensure final path starts with canonicalized current directory; otherwise reject.

No new dependency is required; only standard library API is used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
