### PR TITLE
Potential fix for code scanning alert no. 292: Uncontrolled data used in path expression

### DIFF
--- a/packages/core/src/project.rs
+++ b/packages/core/src/project.rs
@@ -137,23 +137,24 @@ fn verify_relative_to_cwd(path: &Path) -> anyhow::Result<PathBuf> {
     if path.exists() {
         path = dunce::canonicalize(&path)
             .with_context(|| format!("Could not canonicalize {path:?}"))?;
-
-        //check whether it still stars with cwd
-        if !path.starts_with(&cwd) {
-            anyhow::bail!("Provided path escapes the current working directory: {path:?}");
-        }
-
-        if path.is_file() {
-            anyhow::bail!("Provided path is a file, expected a directory: {path:?}");
-        }
     } else if let Some(parent) = path.parent() {
         let canonical_parent = dunce::canonicalize(parent)
             .with_context(|| format!("Could not canonicalize parent directory {parent:?}"))?;
-        if !canonical_parent.starts_with(&cwd) {
-            anyhow::bail!("Provided path resolves outside the current working directory: {path:?}");
-        }
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("Provided path has no valid file name: {path:?}"))?;
+        path = canonical_parent.join(file_name);
     } else {
         anyhow::bail!("Provided path has no valid parent directory: {path:?}");
+    }
+
+    // check whether it still starts with cwd
+    if !path.starts_with(&cwd) {
+        anyhow::bail!("Provided path escapes the current working directory: {path:?}");
+    }
+
+    if path.exists() && path.is_file() {
+        anyhow::bail!("Provided path is a file, expected a directory: {path:?}");
     }
 
     Ok(path)


### PR DESCRIPTION
Potential fix for [https://github.com/fairagro/sciwin/security/code-scanning/292](https://github.com/fairagro/sciwin/security/code-scanning/292)

General fix: ensure filesystem operations use a canonicalized path that is guaranteed to remain inside a trusted base directory, instead of using partially validated raw `PathBuf`.

Best targeted fix in `packages/core/src/project.rs`:
1. In `verify_relative_to_cwd`, after validating parent for non-existing paths, canonicalize the parent and rebuild `path` as `canonical_parent.join(file_name)` so the returned path is always anchored to canonical parent under canonical CWD.
2. Keep (and effectively apply to both branches) the `starts_with(cwd)` and file-type checks on the final `path`.
3. This preserves current behavior (creating directories relative to CWD) while making the returned path deterministic and safer for `create_dir_all`.

No new dependencies are required (uses existing `dunce` and std APIs already in file).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
